### PR TITLE
fix: Add Dash Prefix to rm Command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ default: verilog
 
 verilog:
 	mkdir -p $(BUILD_DIR)
-	rm $(BUILD_DIR)/* -r
+	-rm $(BUILD_DIR)/* -r
 	mill -i nanshan.runMain nanshan.Elaborate --target-dir $(BUILD_DIR)
 
 emu: verilog


### PR DESCRIPTION
This PR adds a dash prefix to the `rm $(BUILD_DIR)/* -r` command in the Makefile. 

The dash prefix is added to ensure that the make process does not stop when the `$(BUILD_DIR)` directory is empty. Without the dash prefix, if the `$(BUILD_DIR)` directory is empty, the Makefile will throw an error and stop the process. With the dash prefix, the make process will continue even if the `rm` command fails.
